### PR TITLE
feat: Add an Inquiries API

### DIFF
--- a/oas3.yaml
+++ b/oas3.yaml
@@ -382,6 +382,38 @@ components:
         photos:
           - https://upload.wikimedia.org/wikipedia/commons/b/b3/Labrador_on_Quantock_%282307909488%29.jpg
 
+    InquiryV1:
+      required:
+        - petId
+        - name
+        - email
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The unique ID of the inquiry in our database.
+          readOnly: true
+        petId:
+          type: string
+          format: uuid
+          description: The unique ID of the pet that this inquiry focuses upon.
+        name:
+          type: string
+          description: The name of the individual making the inquiry.
+        email:
+          type: string
+          description: The email address of the individual making the inquiry.
+        message:
+          type: string
+          description: The message attached with the inquiry, allowing the individual to state their intent.
+      example:
+        id: "be7d7f767ed5e9c595aec44222575a0"
+        petId: "225c5957d7f450baec75a67ede427e9"
+        name: Charles
+        email: charles@xavier.edu
+        message: I'm a collector of wolverines and have a spectacularly large garden and mansion in which they are free to play. Please get in touch.
+
+
     Error:
       type: object
       description: An error describing a problem that the server has encountered or identified.

--- a/oas3.yaml
+++ b/oas3.yaml
@@ -10,8 +10,7 @@ info:
   version: 1.0.0
 
 servers:
-  - url: http://localhost:5000
-  - url: https://localhost:5001
+  - url: https://codess-shelter.azurewebsites.net
 
 tags:
   - name: health
@@ -464,7 +463,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InquiryV1"
-              example: 
+              example:
                 id: "be7d7f767ed5e9c595aec44222575a0"
                 petId: "225c5957d7f450baec75a67ede427e9"
                 name: Charles
@@ -506,6 +505,160 @@ paths:
                 status: 500
                 traceId: 0HLLO6QBUHOL3:00000001
 
+  /api/v1/inquiry/{id}:
+    get:
+      security:
+        - AzureAD:
+          - Inquiries.Read
+      tags:
+        - inquiries
+      summary: Get Inquiry (v1)
+      description: Fetches the details of a specific inquiry from our service.
+      operationId: inquiry_v1
+      parameters:
+        - name: id
+          in: path
+          description: The unique ID of the inquiry you wish to retrieve.
+          required: true
+          schema:
+            type: string
+            pattern: ^[a-f0-9]{32}$
+      responses:
+        200:
+          description: The inquiry which you requested information about.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InquiryV1"
+              example: 
+                id: "be7d7f767ed5e9c595aec44222575a0"
+                petId: "225c5957d7f450baec75a67ede427e9"
+                name: Charles
+                email: charles@xavier.edu
+                message: I'm a collector of wolverines and have a spectacularly large garden and mansion in which they are free to play. Please get in touch.
+        401:
+          description: You did not provide a valid authentication header with your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You did not provide a valid Authorization header."
+                status: 401
+                traceId: 0HLLO6QBUHOL3:00000001
+        403:
+          description: You do not have permission to access this resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You do not have permission to access this resource."
+                status: 403
+                traceId: 0HLLO6QBUHOL3:00000001
+        404:
+          description: The inquiry could not be found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "The pet you requested could not be found."
+                status: 404
+                traceId: 0HLLO6QBUHOL3:00000001
+        500:
+          description: An error occurred on the server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "An internal server error occurred."
+                status: 500
+                traceId: 0HLLO6QBUHOL3:00000001
+
+    patch:
+      security:
+        - AzureAD:
+          - Inquiries.Write
+      tags:
+        - inquiries
+      summary: Modify Inquiry (v1)
+      description: Modifies the information about an inquiry
+      operationId: inquiry_modify_v1
+      parameters:
+        - name: id
+          in: path
+          description: The unique ID of the inquiry you wish to retrieve.
+          required: true
+          schema:
+            type: string
+            pattern: ^[a-f0-9]{32}$
+
+      requestBody:
+        description: The changes you wish to make to the inquiry's information.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InquiryV1"
+            example:
+              name: "Charlie X"
+
+      responses:
+        200:
+          description: The newly modified inquiry's information.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InquiryV1"
+              example: 
+                
+                id: "be7d7f767ed5e9c595aec44222575a0"
+                petId: "225c5957d7f450baec75a67ede427e9"
+                name: Charlie X
+                email: charles@xavier.edu
+                message: I'm a collector of wolverines and have a spectacularly large garden and mansion in which they are free to play. Please get in touch.
+        401:
+          description: You did not provide a valid authentication header with your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You did not provide a valid Authorization header."
+                status: 401
+                traceId: 0HLLO6QBUHOL3:00000001
+        403:
+          description: You do not have permission to access this resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You do not have permission to access this resource."
+                status: 403
+                traceId: 0HLLO6QBUHOL3:00000001
+        404:
+          description: The pet could not be found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "The pet you requested could not be found."
+                status: 404
+                traceId: 0HLLO6QBUHOL3:00000001
+        500:
+          description: An error occurred on the server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "An internal server error occurred."
+                status: 500
+                traceId: 0HLLO6QBUHOL3:00000001
+
 
 components:
   securitySchemes:
@@ -513,10 +666,11 @@ components:
       type: oauth2
       flows:
         authorizationCode:
-          authorizationUrl: https://login.microsoftonline.com/common/oauth2/authorize
-          tokenUrl: https://login.microsoftonline.com/common/oauth2/token
+          authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
+          tokenUrl: https://login.microsoftonline.com/common/oauth2/v2.0/token
           scopes:
             Inquiries.Read: Grants read access to the list of inquiries.
+            Inquiries.Write: Grants write access to existing inquiry objects.
             Pets.Write: Grants write access to the pets collection.
 
   schemas:

--- a/oas3.yaml
+++ b/oas3.yaml
@@ -15,10 +15,26 @@ servers:
 
 tags:
   - name: health
-    description: APIs used to determine whether your service is healthy and running as expected. This API will likely be consumed by your backend service orchestrator and monitoring tooling to automatically identify and isolate/repair broken instances or serve an error page while your service recovers.
+    description: |
+      APIs used to determine whether your service is healthy and running as expected.
+      
+      This API will likely be consumed by your backend service orchestrator and monitoring tooling
+      to automatically identify and isolate/repair broken instances or serve an error page while your
+      service recovers.
 
   - name: pets
-    description: APIs used to enumerate and manage the collection of pets which are available for adoption. This API will likely be consumed primarily by your user interface to show available pets and allow the registration and management of your fluffy friends.
+    description: |
+      APIs used to enumerate and manage the collection of pets which are available for adoption.
+      
+      This API will likely be consumed primarily by your user interface to show available pets
+      and allow the registration and management of your fluffy friends.
+
+  - name: inquiries
+    description: |
+      APIs used to collect and review inquiries made by customers about specific pets.
+
+      This API will primarily be used by customers through a "submit enquiry" form, allowing them
+      to quickly request more information about a specific pet.
 
 paths:
   /api/v1/health:
@@ -96,6 +112,9 @@ paths:
                 traceId: 0HLLO6QBUHOL3:00000001
 
     post:
+      security:
+        - AzureAD:
+          - Pets.Write
       tags:
         - pets
       summary: Add Pet (v1)
@@ -142,6 +161,26 @@ paths:
               example:
                 title: "The request you submitted did not consist of valid JSON data."
                 status: 400
+                traceId: 0HLLO6QBUHOL3:00000001
+        401:
+          description: You did not provide a valid authentication header with your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You did not provide a valid Authorization header."
+                status: 401
+                traceId: 0HLLO6QBUHOL3:00000001
+        403:
+          description: You do not have permission to access this resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You do not have permission to access this resource."
+                status: 403
                 traceId: 0HLLO6QBUHOL3:00000001
         422:
           description: The request you submitted did not meet the schema requirements for a valid pet entry.
@@ -221,6 +260,9 @@ paths:
                 traceId: 0HLLO6QBUHOL3:00000001
 
     patch:
+      security:
+        - AzureAD:
+          - Pets.Write
       tags:
         - pets
       summary: Modify Pet (v1)
@@ -234,6 +276,7 @@ paths:
           schema:
             type: string
             pattern: ^[a-f0-9]{32}$
+
       requestBody:
         description: The changes you wish to make to the pet's information.
         content:
@@ -260,6 +303,26 @@ paths:
                 birthday: 2016-04-15
                 photos:
                   - https://upload.wikimedia.org/wikipedia/commons/b/b3/Labrador_on_Quantock_%282307909488%29.jpg
+        401:
+          description: You did not provide a valid authentication header with your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You did not provide a valid Authorization header."
+                status: 401
+                traceId: 0HLLO6QBUHOL3:00000001
+        403:
+          description: You do not have permission to access this resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You do not have permission to access this resource."
+                status: 403
+                traceId: 0HLLO6QBUHOL3:00000001
         404:
           description: The pet could not be found.
           content:
@@ -281,7 +344,181 @@ paths:
                 status: 500
                 traceId: 0HLLO6QBUHOL3:00000001
 
+  /api/v1/inquiries:
+    get:
+      security:
+        - AzureAD:
+          - Inquiries.Read
+      tags:
+        - inquiries
+      summary: Get Inquiries (v1)
+      description: Gets the list of inquiries which have been submitted by customers.
+      operationId: inquiries_list_v1
+      responses:
+        200:
+          description: The list of inquiries which have been submitted by customers.
+
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/InquiryV1"
+              example: 
+                - id: "be7d7f767ed5e9c595aec44222575a0"
+                  petId: "225c5957d7f450baec75a67ede427e9"
+                  name: Charles
+                  email: charles@xavier.edu
+                  message: I'm a collector of wolverines and have a spectacularly large garden and mansion in which they are free to play. Please get in touch.
+
+
+        400:
+          description: The request you submitted did not consist of valid JSON data.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "The request you submitted did not consist of valid JSON data."
+                status: 400
+                traceId: 0HLLO6QBUHOL3:00000001
+        401:
+          description: You did not provide a valid authentication header with your request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You did not provide a valid Authorization header."
+                status: 401
+                traceId: 0HLLO6QBUHOL3:00000001
+        403:
+          description: You do not have permission to access this resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "You do not have permission to access this resource."
+                status: 403
+                traceId: 0HLLO6QBUHOL3:00000001
+        422:
+          description: The request you submitted did not meet the schema requirements for a valid pet entry.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                errors:
+                  kind:
+                    - The value 'car' is not valid.
+                title: "One or more validation errors occurred."
+                status: 422
+                traceId: 0HLLO6QBUHOL3:00000001
+        500:
+          description: An error occurred on the server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "An internal server error occurred."
+                status: 500
+                traceId: 0HLLO6QBUHOL3:00000001
+
+    post:
+      tags:
+        - inquiries
+      summary: Submit Inquiry (v1)
+      description: |
+                    Submits a new inquiry about the availability of a particular pet for adoption.
+
+                    In general, this endpoint will be used on a pet's details page to allow prospective
+                    adopters to submit their details and request more information about the pet before
+                    visiting the shelter to view them.
+      operationId: inquiries_add_v1
+      requestBody:
+        description: The details of your inquiry.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InquiryV1"
+            example: 
+              petId: "225c5957d7f450baec75a67ede427e9"
+              name: Charles
+              email: charles@xavier.edu
+              message: I'm a collector of wolverines and have a spectacularly large garden and mansion in which they are free to play. Please get in touch.
+
+      responses:
+        201:
+          description: The details of the submitted inquiry.
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The URL at which you will be able to request the details of this inquiry in future.
+              required: true
+              example: "https://localhost:5001/api/v1/inquiry/be7d7f767ed5e9c595aec44222575a0"
+
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InquiryV1"
+              example: 
+                id: "be7d7f767ed5e9c595aec44222575a0"
+                petId: "225c5957d7f450baec75a67ede427e9"
+                name: Charles
+                email: charles@xavier.edu
+                message: I'm a collector of wolverines and have a spectacularly large garden and mansion in which they are free to play. Please get in touch.
+
+
+        400:
+          description: The request you submitted did not consist of valid JSON data.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "The request you submitted did not consist of valid JSON data."
+                status: 400
+                traceId: 0HLLO6QBUHOL3:00000001
+        422:
+          description: The request you submitted did not meet the schema requirements for a valid pet entry.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                errors:
+                  kind:
+                    - The value 'car' is not valid.
+                title: "One or more validation errors occurred."
+                status: 422
+                traceId: 0HLLO6QBUHOL3:00000001
+        500:
+          description: An error occurred on the server.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                title: "An internal server error occurred."
+                status: 500
+                traceId: 0HLLO6QBUHOL3:00000001
+
+
 components:
+  securitySchemes:
+    AzureAD:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://login.microsoftonline.com/common/oauth2/authorize
+          tokenUrl: https://login.microsoftonline.com/common/oauth2/token
+          scopes:
+            Inquiries.Read: Grants read access to the list of inquiries.
+            Pets.Write: Grants write access to the pets collection.
+
   schemas:
     HealthV1:
       required:

--- a/oas3.yaml
+++ b/oas3.yaml
@@ -215,7 +215,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: The unique ID of the idea you wish to retrieve.
+          description: The unique ID of the pet you wish to retrieve.
           required: true
           schema:
             type: string
@@ -270,7 +270,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: The unique ID of the idea you wish to retrieve.
+          description: The unique ID of the pet you wish to modify.
           required: true
           schema:
             type: string
@@ -589,7 +589,7 @@ paths:
       parameters:
         - name: id
           in: path
-          description: The unique ID of the inquiry you wish to retrieve.
+          description: The unique ID of the inquiry you wish to modify.
           required: true
           schema:
             type: string


### PR DESCRIPTION
This adds a `POST /api/v1/inquiries` API endpoint as requested by @nickstenning as well as marking all pet creation/modification endpoints as requiring auth*. My understanding of this request is to better highlight that these types of modification APIs should be protected, to remove the onus on candidates to implement anything that requires auth* and to provide a corresponding `POST` endpoint which does not require auth* for them to play with should they complete the full project spec too quickly.

@nickstenning having gone through this (and understanding that removing all the endpoints will force the backend code to become rather "hacky" to compensate), it seems that this will rather noticably increase the complexity of the implementation. I understand that your objective here is to keep things simple, in which case perhaps espousing that the lack of auth on the pet creation and modification endpoints is a perfectly suitable solution for MVP-ing internally but that production applications should not follow this pattern is a better solution? My primary concern with stripping out the existing endpoints completely is that it leaves us unable to configure the service cleanly come workshop-day. Let me know if you'd like to touch base on this offline to discuss further.